### PR TITLE
Fix port selection when none available

### DIFF
--- a/frmMain.cs
+++ b/frmMain.cs
@@ -51,8 +51,12 @@ namespace ssksSimulation
 
         private void InitializeUIComponents()
         {
-            cboPort.Items.AddRange(SerialPort.GetPortNames());
-            cboPort.SelectedIndex = 0;
+            var ports = SerialPort.GetPortNames();
+            cboPort.Items.AddRange(ports);
+            if (ports.Length > 0)
+            {
+                cboPort.SelectedIndex = 0;
+            }
 
             var freqSetting = Enum.GetNames(typeof(FrequencyWeighting));
             cboFrequencyWeighting.Items.AddRange(freqSetting);


### PR DESCRIPTION
## Summary
- avoid crash when no serial ports are present

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684247789198832cbe8839a4fddfaca1